### PR TITLE
Allow overriding user in Hosts

### DIFF
--- a/lib/ssh/session.go
+++ b/lib/ssh/session.go
@@ -108,6 +108,16 @@ func StartSession(recipe *recipe.BladeRecipe, modifier *SessionModifier) {
 }
 
 func executeSession(sshConfig *ssh.ClientConfig, hostname string, commands []string) {
+
+	// inline user overrides sshConfig.User
+	userHost := strings.Split(hostname, "@")
+	if len(userHost) == 2 {
+		newSSHConfig := *sshConfig
+		sshConfig = &newSSHConfig
+		sshConfig.User = userHost[0]
+		hostname = userHost[1]
+	}
+
 	backoff.RetryNotify(func() error {
 		return startSSHSession(sshConfig, hostname, commands)
 	}, backoff.WithMaxTries(backoff.NewExponentialBackOff(), 3),


### PR DESCRIPTION
additional syntax allowed in `Hosts` list

example recipe:
```
[Overrides]
  User = "admin"

[Required]
  Commands = [
    "hostname"
  ]

  Hosts = [
    "localhost:221",
    "root@localhost:222",
    "customuser@localhost:223",
    "localhost:224"
  ]
```

1st connection will connect as user `admin`
2nd connection will connect as user `root`
3rd connection will connect as user `customuser`
4th connection will connect as user `admin`

resolves #8